### PR TITLE
expose BBTree Query of shapes in space

### DIFF
--- a/space.go
+++ b/space.go
@@ -344,6 +344,14 @@ func (space *Space) Space() *Space {
 	return space
 }
 
+func (space *Space) Query(obj Indexable, aabb AABB, fnc SpatialIndexQueryFunc) {
+	space.activeShapes.Query(obj, aabb, fnc)
+}
+
+func (space *Space) QueryStatic(obj Indexable, aabb AABB, fnc SpatialIndexQueryFunc) {
+	space.staticShapes.Query(obj, aabb, fnc)
+}
+
 func (space *Space) SpacePointQueryFirst(point vect.Vect, layers Layer, group Group, checkSensors bool) (shape *Shape) {
 
 	found := false


### PR DESCRIPTION
Great port! Minor addition, it's really handy to be able to query the spatial index of active shapes without having to keep and maintain a separate BBTree since activeShapes is private.
