### PR TITLE
Make Body.UpdateVelocityFunc useable

### DIFF
--- a/body.go
+++ b/body.go
@@ -348,11 +348,15 @@ func (body *Body) UpdatePosition(dt vect.Float) {
 	body.w_bias = 0.0
 }
 
-func (body *Body) UpdateVelocity(gravity vect.Vect, damping, dt vect.Float) {
+func (body *Body) updateVelocityProxy(gravity vect.Vect, damping, dt vect.Float) {
 	if body.UpdateVelocityFunc != nil {
 		body.UpdateVelocityFunc(body, gravity, damping, dt)
 		return
 	}
+	body.UpdateVelocity(gravity, damping, dt)
+}
+
+func (body *Body) UpdateVelocity(gravity vect.Vect, damping, dt vect.Float) {
 	body.v = vect.Add(vect.Mult(body.v, damping), vect.Mult(vect.Add(gravity, vect.Mult(body.f, body.m_inv)), dt))
 
 	body.w = (body.w * damping) + (body.t * body.i_inv * dt)

--- a/space.go
+++ b/space.go
@@ -236,10 +236,10 @@ func (space *Space) Step(dt vect.Float) {
 	for _, body := range bodies {
 		if body.Enabled {
 			if body.IgnoreGravity {
-				body.UpdateVelocity(vect.Vector_Zero, damping, dt)
+				body.updateVelocityProxy(vect.Vector_Zero, damping, dt)
 				continue
 			}
-			body.UpdateVelocity(space.Gravity, damping, dt)
+			body.updateVelocityProxy(space.Gravity, damping, dt)
 		}
 	}
 


### PR DESCRIPTION
I am a total golang rookie, so forgive me if this is all based on me misunderstanding things :)

It seems to me that the Body.UpdateVelocityFunc function should be able to call Body.UpdateVelocity without causing an infinite recursive loop. I'm not sure how else to apply the modified velocity computations.

The inspiration came from [here](https://github.com/slembcke/Chipmunk2D/blob/master/demo/Planet.c#L36). Notice planetGravityVelocityFunc calling cpBodyUpdateVelocity.

If you don't like my naming of the updateVelocityProxy function, I'm open to suggestions.

Thanks a bunch for this port - It runs really well and it's pretty much just what I was looking for.